### PR TITLE
Handle message expiration cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=[
         'Django>=1.4',
     ],
-    test_suite='runtests.run_tests',
     license="BSD",
     zip_safe=False,
     keywords='django-stored-messages',

--- a/stored_messages/backends/base.py
+++ b/stored_messages/backends/base.py
@@ -3,7 +3,7 @@ class StoredMessagesBackend(object):
     """
 
     """
-    def create_message(self, level, msg_text, extra_tags):
+    def create_message(self, level, msg_text, extra_tags, date=None):
         """
         Create and return a `Message` instance.
         Instance types depend on backends implementation.
@@ -12,6 +12,7 @@ class StoredMessagesBackend(object):
             `level`: message level (see django.contrib.messages)
             `msg_text`: what you think it is
             `extra_tags`: see django.contrib.messages
+            `date`: a DateTime (optional)
 
         Return:
             `Message` instance
@@ -129,6 +130,18 @@ class StoredMessagesBackend(object):
 
         Return:
             True if type is correct, False otherwise
+        """
+        raise NotImplementedError()
+
+    def expired_messages_cleanup(self):
+        """
+        Remove messages that have been expired.
+
+        Params:
+            None
+
+        Return:
+           None
         """
         raise NotImplementedError()
 

--- a/stored_messages/backends/default/backend.py
+++ b/stored_messages/backends/default/backend.py
@@ -1,6 +1,9 @@
+from django.utils import timezone
+
 from ..base import StoredMessagesBackend
 from ..exceptions import MessageTypeNotSupported, MessageDoesNotExist
 from ...models import Inbox, Message, MessageArchive
+from ...settings import stored_messages_settings
 
 
 class DefaultBackend(StoredMessagesBackend):
@@ -37,8 +40,15 @@ class DefaultBackend(StoredMessagesBackend):
         except Inbox.DoesNotExist:
             raise MessageDoesNotExist("Message with id %s does not exist" % msg_id)
 
-    def create_message(self, level, msg_text, extra_tags=''):
-        m_instance = Message.objects.create(message=msg_text, level=level, tags=extra_tags)
+    def create_message(self, level, msg_text, extra_tags='', date=None):
+        kwargs = {
+            'message': msg_text,
+            'level': level,
+            'tags': extra_tags,
+        }
+        if date:
+            kwargs['date'] = date
+        m_instance = Message.objects.create(**kwargs)
         return m_instance
 
     def archive_store(self, users, msg_instance):
@@ -53,6 +63,11 @@ class DefaultBackend(StoredMessagesBackend):
 
     def can_handle(self, message):
         return isinstance(message, Message)
+
+    def expired_messages_cleanup(self):
+        expiration_date = timezone.now() + timezone.timedelta(
+            days=-stored_messages_settings.MESSAGE_EXPIRE_DAYS)
+        Message.objects.filter(date__lte=expiration_date).delete()
 
     def _flush(self):
         Inbox.objects.all().delete()

--- a/stored_messages/settings.py
+++ b/stored_messages/settings.py
@@ -39,6 +39,7 @@ DEFAULTS = {
         STORED_ERROR: 'stored error',
     }),
     'INBOX_EXPIRE_DAYS': 30,
+    'MESSAGE_EXPIRE_DAYS': 120,
     'STORAGE_BACKEND': 'stored_messages.backends.DefaultBackend',
     # Only for Redis backend
     'REDIS_URL': 'redis://username:password@localhost:6379/0',


### PR DESCRIPTION
Add machinery to support the cleanup of messages older than a
configurable threshold. Default threshold is 120 days as github.
    
Store message api has been extended for being able to pass a
specific date. Won't be used much on production but it's useful
for testing.
