### PR TITLE
Add url field to Message

### DIFF
--- a/stored_messages/api.py
+++ b/stored_messages/api.py
@@ -10,7 +10,7 @@ BackendClass = stored_messages_settings.STORAGE_BACKEND
 backend = BackendClass()
 
 
-def add_message_for(users, level, message_text, extra_tags='', fail_silently=False):
+def add_message_for(users, level, message_text, extra_tags='', date=None, fail_silently=False):
     """
     Send a message to a list of users without passing through `django.contrib.messages`
 
@@ -18,9 +18,10 @@ def add_message_for(users, level, message_text, extra_tags='', fail_silently=Fal
     :param level: message level
     :param message_text: the string containing the message
     :param extra_tags: like the Django api, a string containing extra tags for the message
+    :param date: a date, different than the default timezone.now
     :param fail_silently: not used at the moment
     """
-    m = backend.create_message(level, message_text, extra_tags)
+    m = backend.create_message(level, message_text, extra_tags, date)
     backend.archive_store(users, m)
     backend.inbox_store(users, m)
 

--- a/stored_messages/api.py
+++ b/stored_messages/api.py
@@ -10,7 +10,7 @@ BackendClass = stored_messages_settings.STORAGE_BACKEND
 backend = BackendClass()
 
 
-def add_message_for(users, level, message_text, extra_tags='', date=None, fail_silently=False):
+def add_message_for(users, level, message_text, extra_tags='', date=None, url=None, fail_silently=False):
     """
     Send a message to a list of users without passing through `django.contrib.messages`
 
@@ -19,9 +19,10 @@ def add_message_for(users, level, message_text, extra_tags='', date=None, fail_s
     :param message_text: the string containing the message
     :param extra_tags: like the Django api, a string containing extra tags for the message
     :param date: a date, different than the default timezone.now
+    :param url: an optional url
     :param fail_silently: not used at the moment
     """
-    m = backend.create_message(level, message_text, extra_tags, date)
+    m = backend.create_message(level, message_text, extra_tags, date, url)
     backend.archive_store(users, m)
     backend.inbox_store(users, m)
 

--- a/stored_messages/api.py
+++ b/stored_messages/api.py
@@ -27,17 +27,19 @@ def add_message_for(users, level, message_text, extra_tags='', date=None, url=No
     backend.inbox_store(users, m)
 
 
-def broadcast_message(level, message_text, extra_tags='', fail_silently=False):
+def broadcast_message(level, message_text, extra_tags='', date=None, url=None, fail_silently=False):
     """
     Send a message to all users aka broadcast.
 
     :param level: message level
     :param message_text: the string containing the message
     :param extra_tags: like the Django api, a string containing extra tags for the message
+    :param date: a date, different than the default timezone.now
+    :param url: an optional url
     :param fail_silently: not used at the moment
     """
     users = get_user_model().objects.all()
-    add_message_for(users, level, message_text, extra_tags=extra_tags, fail_silently=fail_silently)
+    add_message_for(users, level, message_text, extra_tags=extra_tags, date=date, url=url, fail_silently=fail_silently)
 
 
 def mark_read(user, message):

--- a/stored_messages/backends/default/backend.py
+++ b/stored_messages/backends/default/backend.py
@@ -44,11 +44,12 @@ class DefaultBackend(StoredMessagesBackend):
         except Inbox.DoesNotExist:
             raise MessageDoesNotExist("Message with id %s does not exist" % msg_id)
 
-    def create_message(self, level, msg_text, extra_tags='', date=None):
+    def create_message(self, level, msg_text, extra_tags='', date=None, url=None):
         kwargs = {
             'message': msg_text,
             'level': level,
             'tags': extra_tags,
+            'url': url,
         }
         if date:
             kwargs['date'] = date

--- a/stored_messages/backends/redis/backend.py
+++ b/stored_messages/backends/redis/backend.py
@@ -20,7 +20,7 @@ except ImportError:
     pass
 
 
-Message = namedtuple('Message', ['id', 'message', 'level', 'tags', 'date'])
+Message = namedtuple('Message', ['id', 'message', 'level', 'tags', 'date', 'url'])
 
 
 class RedisBackend(StoredMessagesBackend):
@@ -57,7 +57,7 @@ class RedisBackend(StoredMessagesBackend):
     def _list(self, key_tpl, user):
         return self._list_key(key_tpl % user.pk)
 
-    def create_message(self, level, msg_text, extra_tags='', date=None):
+    def create_message(self, level, msg_text, extra_tags='', date=None, url=None):
         """
         Message instances are namedtuples of type `Message`.
         The date field is already serialized in datetime.isoformat ECMA-262 format
@@ -75,7 +75,7 @@ class RedisBackend(StoredMessagesBackend):
         fingerprint = r + msg_text
 
         msg_id = hashlib.sha256(fingerprint.encode('ascii', 'ignore')).hexdigest()
-        return Message(id=msg_id, message=msg_text, level=level, tags=extra_tags, date=r)
+        return Message(id=msg_id, message=msg_text, level=level, tags=extra_tags, date=r, url=url)
 
     def inbox_list(self, user):
         if user.is_anonymous():

--- a/stored_messages/models.py
+++ b/stored_messages/models.py
@@ -18,6 +18,7 @@ class Message(models.Model):
     message = models.TextField()
     level = models.IntegerField()
     tags = models.TextField()
+    url = models.URLField(null=True, blank=True)
     date = models.DateTimeField(default=timezone.now)
 
     def __str__(self):

--- a/stored_messages/serializers.py
+++ b/stored_messages/serializers.py
@@ -7,3 +7,4 @@ class InboxSerializer(serializers.Serializer):
     level = serializers.IntegerField()
     tags = serializers.CharField()
     date = serializers.DateTimeField(format=None)
+    url = serializers.URLField(required=False)

--- a/stored_messages/tests/test_api.py
+++ b/stored_messages/tests/test_api.py
@@ -58,10 +58,24 @@ class TestApi(BaseTest):
         user2 = get_user_model().objects.create_user("user2", "u2@user.com", "123456")
         user3 = get_user_model().objects.create_user("user3", "u3@user.com", "123456")
 
-        broadcast_message( stored_messages.STORED_INFO, 'broadcast test message')
+        now = timezone.now() + timezone.timedelta(days=-1)
+        url = 'http://example.com/error'
+        broadcast_message( stored_messages.STORED_INFO, 'broadcast test message', 'extra', now, url)
         self.assertEqual(Inbox.objects.get(user=user1.id).message.message, "broadcast test message")
         self.assertEqual(Inbox.objects.get(user=user2.id).message.message, "broadcast test message")
         self.assertEqual(Inbox.objects.get(user=user3.id).message.message, "broadcast test message")
+
+        self.assertEqual(Inbox.objects.get(user=user1.id).message.tags, 'extra')
+        self.assertEqual(Inbox.objects.get(user=user2.id).message.tags, 'extra')
+        self.assertEqual(Inbox.objects.get(user=user3.id).message.tags, 'extra')
+
+        self.assertEqual(Inbox.objects.get(user=user1.id).message.date, now)
+        self.assertEqual(Inbox.objects.get(user=user2.id).message.date, now)
+        self.assertEqual(Inbox.objects.get(user=user3.id).message.date, now)
+
+        self.assertEqual(Inbox.objects.get(user=user1.id).message.url, url)
+        self.assertEqual(Inbox.objects.get(user=user2.id).message.url, url)
+        self.assertEqual(Inbox.objects.get(user=user3.id).message.url, url)
 
         self.assertEqual(MessageArchive.objects.get(user=user1.id).message.message,
                          "broadcast test message")

--- a/stored_messages/tests/test_api.py
+++ b/stored_messages/tests/test_api.py
@@ -29,8 +29,10 @@ class TestApi(BaseTest):
 
     def test_add_message_for(self):
         now = timezone.now() + timezone.timedelta(days=-1)
+        url = 'http://example.com/error'
+
         user2 = get_user_model().objects.create_user("another_user", "u@user.com", "123456")
-        add_message_for([user2, self.user], stored_messages.STORED_ERROR, 'Multiple errors', 'extra', now)
+        add_message_for([user2, self.user], stored_messages.STORED_ERROR, 'Multiple errors', 'extra', now, url)
         self.assertEqual(Inbox.objects.count(), 2)
         self.assertEqual(MessageArchive.objects.count(), 2)
 
@@ -39,6 +41,9 @@ class TestApi(BaseTest):
 
         self.assertEqual(Inbox.objects.get(user=user2.id).message.date, now)
         self.assertEqual(Inbox.objects.get(user=self.user).message.date, now)
+
+        self.assertEqual(Inbox.objects.get(user=user2.id).message.url, url)
+        self.assertEqual(Inbox.objects.get(user=self.user).message.url, url)
 
         self.assertEqual(Inbox.objects.get(user=user2.id).message.message, "Multiple errors")
         self.assertEqual(Inbox.objects.get(user=self.user).message.message, "Multiple errors")


### PR DESCRIPTION
Add an optional url field to Message, this is useful if you want to use django-stored-messages for notifications where you usually have an url pointing to the event.

While at it the create_message api is expanded to support passing the date.