### PR TITLE
Bring tag behavior in line with builtin messages

### DIFF
--- a/stored_messages/backends/default/backend.py
+++ b/stored_messages/backends/default/backend.py
@@ -53,7 +53,7 @@ class DefaultBackend(StoredMessagesBackend):
         }
         if date:
             kwargs['date'] = date
-        m_instance = Message.objects.create(**kwargs)
+        m_instance = Message.objects.create_message(**kwargs)
         return m_instance
 
     def archive_store(self, users, msg_instance):

--- a/stored_messages/models.py
+++ b/stored_messages/models.py
@@ -4,9 +4,35 @@ from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from django.contrib.messages.utils import get_level_tags
 
 from .compat import AUTH_USER_MODEL
 from .settings import stored_messages_settings
+
+LEVEL_TAGS = get_level_tags()
+
+
+class MessageManager(models.Manager):
+    """
+    This custom manager for our Message model allows us to better emulate
+    the behavior of builtin Message objects by automatically including the
+    applicable level_tag, if available, in the message's tags.
+    """
+    def create_message(self, *args, **kwargs):
+        message = self.create(**kwargs)
+        tags = message.tags
+        level_tag = message.level_tag
+
+        if tags and level_tag:
+            tags = ' '.join([tags, level_tag])
+        elif tags:
+            tags = tags
+        else:
+            tags = level_tag
+
+        message.tags = tags
+        message.save()
+        return message
 
 
 @python_2_unicode_compatible
@@ -21,8 +47,14 @@ class Message(models.Model):
     url = models.URLField(null=True, blank=True)
     date = models.DateTimeField(default=timezone.now)
 
+    objects = MessageManager()
+
     def __str__(self):
         return self.message
+
+    @property
+    def level_tag(self):
+        return LEVEL_TAGS.get(self.level, '')
 
 
 @python_2_unicode_compatible

--- a/stored_messages/tests/test_api.py
+++ b/stored_messages/tests/test_api.py
@@ -36,8 +36,8 @@ class TestApi(BaseTest):
         self.assertEqual(Inbox.objects.count(), 2)
         self.assertEqual(MessageArchive.objects.count(), 2)
 
-        self.assertEqual(Inbox.objects.get(user=user2.id).message.tags, 'extra')
-        self.assertEqual(Inbox.objects.get(user=self.user).message.tags, 'extra')
+        self.assertEqual(Inbox.objects.get(user=user2.id).message.tags, 'extra persisted error')
+        self.assertEqual(Inbox.objects.get(user=self.user).message.tags, 'extra persisted error')
 
         self.assertEqual(Inbox.objects.get(user=user2.id).message.date, now)
         self.assertEqual(Inbox.objects.get(user=self.user).message.date, now)
@@ -60,14 +60,14 @@ class TestApi(BaseTest):
 
         now = timezone.now() + timezone.timedelta(days=-1)
         url = 'http://example.com/error'
-        broadcast_message( stored_messages.STORED_INFO, 'broadcast test message', 'extra', now, url)
+        broadcast_message(stored_messages.STORED_INFO, 'broadcast test message', 'extra', now, url)
         self.assertEqual(Inbox.objects.get(user=user1.id).message.message, "broadcast test message")
         self.assertEqual(Inbox.objects.get(user=user2.id).message.message, "broadcast test message")
         self.assertEqual(Inbox.objects.get(user=user3.id).message.message, "broadcast test message")
 
-        self.assertEqual(Inbox.objects.get(user=user1.id).message.tags, 'extra')
-        self.assertEqual(Inbox.objects.get(user=user2.id).message.tags, 'extra')
-        self.assertEqual(Inbox.objects.get(user=user3.id).message.tags, 'extra')
+        self.assertEqual(Inbox.objects.get(user=user1.id).message.tags, 'extra persisted info')
+        self.assertEqual(Inbox.objects.get(user=user2.id).message.tags, 'extra persisted info')
+        self.assertEqual(Inbox.objects.get(user=user3.id).message.tags, 'extra persisted info')
 
         self.assertEqual(Inbox.objects.get(user=user1.id).message.date, now)
         self.assertEqual(Inbox.objects.get(user=user2.id).message.date, now)


### PR DESCRIPTION
This PR fixes issue #21 -- it adds a level_tag property to the message model, and adds a custom message manager with a method that automatically adds any applicable level_tag to any user-defined tags. Result is that tag behavior now matches builtin messages. I didn't add any new tests for this functionality; I just changed the existing tag-related assertions to match the new expected behavior. I'm happy to add new tests if you think it's necessary.