### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Django Stored Messages
         :target: https://coveralls.io/r/evonove/django-stored-messages
 
 .. image:: http://readthedocs.org/projects/django-stored-messages/badge/?version=latest
-    :target: http://django-stored-messages.readthedocs.org/en/latest/?badge=latest
+    :target: https://django-stored-messages.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. image:: https://badge.fury.io/py/django-stored-messages.png
@@ -45,10 +45,10 @@ if it's **not supported anymore**. Anyway, plan a migration to a newer version.
 Documentation
 -------------
 
-The full documentation is at http://django-stored-messages.rtfd.org. It includes `migration instructions`_ if you're
+The full documentation is at https://django-stored-messages.readthedocs.io. It includes `migration instructions`_ if you're
 migrating from an earlier version of ``stored_messages``.
 
-.. _migration instructions: http://django-stored-messages.readthedocs.org/en/latest/migrations.html
+.. _migration instructions: https://django-stored-messages.readthedocs.io/en/latest/migrations.html
 
 Quickstart
 ----------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.