### PR TITLE
Fix inbox_get method of DefaultBackend

### DIFF
--- a/stored_messages/api.py
+++ b/stored_messages/api.py
@@ -1,6 +1,3 @@
-from .settings import stored_messages_settings
-
-
 __all__ = (
     'add_message_for',
     'broadcast_message',
@@ -21,6 +18,7 @@ def add_message_for(users, level, message_text, extra_tags='', date=None, url=No
     :param url: an optional url
     :param fail_silently: not used at the moment
     """
+    from .settings import stored_messages_settings
     BackendClass = stored_messages_settings.STORAGE_BACKEND
     backend = BackendClass()
     m = backend.create_message(level, message_text, extra_tags, date, url)
@@ -53,6 +51,7 @@ def mark_read(user, message):
     :param user: user instance for the recipient
     :param message: a Message instance to mark as read
     """
+    from .settings import stored_messages_settings
     BackendClass = stored_messages_settings.STORAGE_BACKEND
     backend = BackendClass()
     backend.inbox_delete(user, message)
@@ -64,6 +63,7 @@ def mark_all_read(user):
 
     :param user: user instance for the recipient
     """
+    from .settings import stored_messages_settings
     BackendClass = stored_messages_settings.STORAGE_BACKEND
     backend = BackendClass()
     backend.inbox_purge(user)

--- a/stored_messages/backends/default/backend.py
+++ b/stored_messages/backends/default/backend.py
@@ -40,7 +40,7 @@ class DefaultBackend(StoredMessagesBackend):
 
     def inbox_get(self, user, msg_id):
         try:
-            return Inbox.objects.get(pk=msg_id).message
+            return Inbox.objects.get(message__pk=msg_id).message
         except Inbox.DoesNotExist:
             raise MessageDoesNotExist("Message with id %s does not exist" % msg_id)
 


### PR DESCRIPTION
While working with the REST API, I ran into a problem with the inbox-detail view.

The inbox-list view serializes all messages in a user's inbox. The "id" values in the JSON response are primary keys of Message objects (when using the DefaultBackend). The /inbox/{id}/ endpoint provides a detail view of those messages. In the process, however, the "id" (of a message) is inadvertently used as the primary key of an Inbox object:

https://github.com/evonove/django-stored-messages/blob/master/stored_messages/backends/default/backend.py#L43

Why doesn't this show up in the current tests? Message and Inbox objects are often created in pairs. If the database starts numbering both tables at 1, corresponding objects will have the same primary key. Of course, you cannot rely on this.

I created a test that demonstrates the problem. By sending the same message to two users, the primary keys of the underlying message and inbox tables are no longer synchronous. In this situation, user2 can no longer obtain a detail view if user1 marks his message as read.

While writing my test, I noticed that api functions such as "add_message_for" are not using the STORAGE_BACKEND overridden by TestRESTApiWithRedis. I fixed this as well, by doing an inline import. NB: views.py is already doing it this way, so this fix is consistent with that.